### PR TITLE
Add database schema and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # prepLab
+
+This repo contains a small example project using [Deno](https://deno.land) with a backend and a simple frontend.
+
+## Requirements
+
+- [Deno](https://deno.land/) >= 1.40 (or any recent version)
+
+## Running the server
+
+Use the built in task to start the server:
+
+```bash
+deno task start
+```
+
+The server listens on http://localhost:8000 and serves:
+
+- `GET /api/greet` - returns a greeting JSON message.
+- `GET /api/equipment` - list of all stock equipment by room and drawer.
+- `GET /api/cards` - list of prep lab cards. Add `?items=1` to include
+  associated equipment.
+- Static files from the `public` directory, including `index.html`.
+
+Open your browser to [http://localhost:8000](http://localhost:8000) to see the
+interactive interface. Use the search box to filter by class and view each card
+along with the equipment and storage locations it requires.

--- a/database.ts
+++ b/database.ts
@@ -1,0 +1,71 @@
+import { DB } from "https://deno.land/x/sqlite/mod.ts";
+
+const db = new DB("lab.db");
+
+// Prep lab cards are associated with a class and contain card text
+// e.g. equipment lists or instructions for that class.
+db.execute(`
+  CREATE TABLE IF NOT EXISTS prep_lab_cards (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    class TEXT NOT NULL,
+    card_text TEXT NOT NULL
+  )
+`);
+
+// Stock equipment by room and drawer code
+// This keeps track of where each item is stored in the school.
+db.execute(`
+  CREATE TABLE IF NOT EXISTS stock_equipment (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    room TEXT NOT NULL,
+    drawer_code TEXT NOT NULL
+  )
+`);
+
+// Link table mapping prep lab cards to the equipment they use
+db.execute(`
+  CREATE TABLE IF NOT EXISTS card_equipment (
+    card_id INTEGER NOT NULL,
+    equipment_id INTEGER NOT NULL,
+    FOREIGN KEY(card_id) REFERENCES prep_lab_cards(id),
+    FOREIGN KEY(equipment_id) REFERENCES stock_equipment(id)
+  )
+`);
+
+// Insert a few example records on first run
+const row = [...db.query("SELECT count(*) FROM prep_lab_cards")][0][0] as number;
+if (row === 0) {
+  db.query(
+    "INSERT INTO prep_lab_cards (class, card_text) VALUES (?, ?)",
+    ["Biology 1005", "Basic Biology equipment"],
+  );
+  db.query(
+    "INSERT INTO prep_lab_cards (class, card_text) VALUES (?, ?)",
+    ["Chemistry 1111", "Chemistry lab kit"],
+  );
+
+  db.query(
+    "INSERT INTO stock_equipment (name, room, drawer_code) VALUES (?, ?, ?)",
+    ["Microscope", "101", "A1"],
+  );
+  db.query(
+    "INSERT INTO stock_equipment (name, room, drawer_code) VALUES (?, ?, ?)",
+    ["Test Tubes", "102", "B5"],
+  );
+  db.query(
+    "INSERT INTO stock_equipment (name, room, drawer_code) VALUES (?, ?, ?)",
+    ["Beaker Set", "102", "B6"],
+  );
+
+  // Retrieve inserted card and equipment ids
+  const cardIds = [...db.query("SELECT id FROM prep_lab_cards")].map((r) => r[0]);
+  const eqIds = [...db.query("SELECT id FROM stock_equipment")].map((r) => r[0]);
+
+  // Assume order: first card uses first equipment, second card uses second and third
+  db.query("INSERT INTO card_equipment (card_id, equipment_id) VALUES (?, ?)", [cardIds[0], eqIds[0]]);
+  db.query("INSERT INTO card_equipment (card_id, equipment_id) VALUES (?, ?)", [cardIds[1], eqIds[1]]);
+  db.query("INSERT INTO card_equipment (card_id, equipment_id) VALUES (?, ?)", [cardIds[1], eqIds[2]]);
+}
+
+export { db };

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "start": "deno run --allow-net --allow-read --allow-write server.ts"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PrepLab Cards</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 1em; background: #f5f5f5; }
+    #search { width: 100%; padding: 0.5em; margin-bottom: 1em; }
+    .card { background: #fffbe6; border: 1px solid #ccc; border-radius: 4px; box-shadow: 2px 2px 6px rgba(0,0,0,0.1); margin-bottom: 1em; padding: 1em; }
+    .card h3 { margin-top: 0; }
+    .item-list { list-style: none; padding-left: 1em; }
+  </style>
+</head>
+<body>
+  <h1>PrepLab Cards</h1>
+  <input type="text" id="search" placeholder="Search by class..." />
+  <div id="cards"></div>
+
+  <script type="module">
+    let allCards = [];
+
+    async function loadCards() {
+      const res = await fetch('/api/cards?items=1');
+      allCards = await res.json();
+      renderCards(allCards);
+    }
+
+    function renderCards(cards) {
+      const container = document.getElementById('cards');
+      container.innerHTML = '';
+      for (const card of cards) {
+        const div = document.createElement('div');
+        div.className = 'card';
+        const title = document.createElement('h3');
+        title.textContent = card.class;
+        const text = document.createElement('p');
+        text.textContent = card.card_text;
+        const ul = document.createElement('ul');
+        ul.className = 'item-list';
+        for (const item of card.items) {
+          const li = document.createElement('li');
+          li.textContent = `${item.name} - Room ${item.room}, Drawer ${item.drawer_code}`;
+          ul.appendChild(li);
+        }
+        div.appendChild(title);
+        div.appendChild(text);
+        div.appendChild(ul);
+        container.appendChild(div);
+      }
+    }
+
+    document.getElementById('search').addEventListener('input', (e) => {
+      const value = e.target.value.toLowerCase();
+      const filtered = allCards.filter(c => c.class.toLowerCase().includes(value));
+      renderCards(filtered);
+    });
+
+    loadCards();
+  </script>
+</body>
+</html>

--- a/server.ts
+++ b/server.ts
@@ -1,0 +1,69 @@
+import { serveFile } from "https://deno.land/std@0.214.0/http/file_server.ts";
+import { serve } from "https://deno.land/std@0.214.0/http/server.ts";
+import { db } from "./database.ts";
+
+async function handler(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.pathname === "/api/greet") {
+    const body = JSON.stringify({ message: "Hello from Deno!" });
+    return new Response(body, {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (url.pathname === "/api/equipment") {
+    const equipment = [...db.query(
+      "SELECT id, name, room, drawer_code FROM stock_equipment",
+    )].map(([id, name, room, drawer_code]) => ({
+      id,
+      name,
+      room,
+      drawer_code,
+    }));
+    return new Response(JSON.stringify(equipment), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (url.pathname === "/api/cards") {
+    const includeItems = url.searchParams.get("items") === "1";
+    const cards = [...db.query(
+      "SELECT id, class, card_text FROM prep_lab_cards",
+    )].map(([id, cls, cardText]) => ({
+      id,
+      class: cls,
+      card_text: cardText,
+    }));
+
+    if (includeItems) {
+      for (const card of cards) {
+        card.items = [...db.query(
+          `SELECT se.id, se.name, se.room, se.drawer_code
+           FROM card_equipment ce
+           JOIN stock_equipment se ON ce.equipment_id = se.id
+           WHERE ce.card_id = ?`,
+          [card.id],
+        )].map(([id, name, room, drawer]) => ({
+          id,
+          name,
+          room,
+          drawer_code: drawer,
+        }));
+      }
+    }
+
+    return new Response(JSON.stringify(cards), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const filePath = url.pathname === "/" ? "/index.html" : url.pathname;
+  try {
+    return await serveFile(request, `public${filePath}`);
+  } catch (_e) {
+    return new Response("Not Found", { status: 404 });
+  }
+}
+
+console.log("Server running on http://localhost:8000");
+await serve(handler, { addr: ":8000" });


### PR DESCRIPTION
## Summary
- initialize SQLite DB with tables for prep lab cards and stock equipment
- expose `/api/equipment` and `/api/cards` endpoints
- show equipment on the example frontend
- document API routes and update run permissions
- create an interactive UI that shows lab cards with equipment
- include search by class

## Testing
- `deno --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd67196bc83238b0f2ff0420ad56f