### PR TITLE
Add auth and collaborative task system

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,27 @@
+import { create, getNumericDate, verify } from "https://deno.land/x/djwt/mod.ts";
+
+const JWT_SECRET = Deno.env.get("JWT_SECRET") || "verysecret";
+
+export interface Session {
+  id: number;
+  username: string;
+  role: string;
+}
+
+export async function createToken(session: Session): Promise<string> {
+  return await create({ alg: "HS256", typ: "JWT" }, {
+    id: session.id,
+    username: session.username,
+    role: session.role,
+    exp: getNumericDate(60 * 60 * 8),
+  }, JWT_SECRET);
+}
+
+export async function verifyToken(token: string): Promise<Session | null> {
+  try {
+    const payload = await verify(token, JWT_SECRET, "HS256");
+    return payload as Session;
+  } catch {
+    return null;
+  }
+}

--- a/database.ts
+++ b/database.ts
@@ -1,4 +1,5 @@
 import { DB } from "https://deno.land/x/sqlite/mod.ts";
+import { hash } from "https://deno.land/x/bcrypt/mod.ts";
 
 const db = new DB("lab.db");
 
@@ -30,6 +31,31 @@ db.execute(`
     equipment_id INTEGER NOT NULL,
     FOREIGN KEY(card_id) REFERENCES prep_lab_cards(id),
     FOREIGN KEY(equipment_id) REFERENCES stock_equipment(id)
+  )
+`);
+
+// Simple user table with role and a preferred color for task check marks
+db.execute(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL,
+    role TEXT NOT NULL,
+    color TEXT NOT NULL
+  )
+`);
+
+// Tasks belong to a card and can be checked by any user
+db.execute(`
+  CREATE TABLE IF NOT EXISTS card_tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    card_id INTEGER NOT NULL,
+    description TEXT NOT NULL,
+    is_checked INTEGER DEFAULT 0,
+    checked_by INTEGER,
+    checked_at TEXT,
+    FOREIGN KEY(card_id) REFERENCES prep_lab_cards(id),
+    FOREIGN KEY(checked_by) REFERENCES users(id)
   )
 `);
 
@@ -66,6 +92,29 @@ if (row === 0) {
   db.query("INSERT INTO card_equipment (card_id, equipment_id) VALUES (?, ?)", [cardIds[0], eqIds[0]]);
   db.query("INSERT INTO card_equipment (card_id, equipment_id) VALUES (?, ?)", [cardIds[1], eqIds[1]]);
   db.query("INSERT INTO card_equipment (card_id, equipment_id) VALUES (?, ?)", [cardIds[1], eqIds[2]]);
+
+  // Create demo users
+  const rootPass = await hash("rootpass");
+  const userPass = await hash("userpass");
+  db.query(
+    "INSERT INTO users (username, password, role, color) VALUES (?, ?, ?, ?)",
+    ["root", rootPass, "root", "#ff0000"],
+  );
+  db.query(
+    "INSERT INTO users (username, password, role, color) VALUES (?, ?, ?, ?)",
+    ["alice", userPass, "user", "#0000ff"],
+  );
+
+  // Seed a couple of tasks for the first card
+  const biologyCard = cardIds[0];
+  db.query(
+    "INSERT INTO card_tasks (card_id, description) VALUES (?, ?)",
+    [biologyCard, "Clean microscopes"],
+  );
+  db.query(
+    "INSERT INTO card_tasks (card_id, description) VALUES (?, ?)",
+    [biologyCard, "Return slides"],
+  );
 }
 
 export { db };

--- a/public/index.html
+++ b/public/index.html
@@ -13,17 +13,58 @@
   </style>
 </head>
 <body>
-  <h1>PrepLab Cards</h1>
-  <input type="text" id="search" placeholder="Search by class..." />
+  <div id="login">
+    <input id="user" placeholder="username" />
+    <input id="pass" type="password" placeholder="password" />
+    <button id="loginBtn">Login</button>
+  </div>
+  <h1 style="display:none" id="title">PrepLab Cards</h1>
+  <input type="text" id="search" placeholder="Search by class..." style="display:none" />
   <div id="cards"></div>
 
   <script type="module">
     let allCards = [];
+    let token = '';
+    let socket;
+
+    async function login() {
+      const username = document.getElementById('user').value;
+      const password = document.getElementById('pass').value;
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        body: JSON.stringify({ username, password }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!res.ok) return alert('login failed');
+      const data = await res.json();
+      token = data.token;
+      document.getElementById('login').style.display = 'none';
+      document.getElementById('title').style.display = 'block';
+      document.getElementById('search').style.display = 'block';
+      connectWS();
+      loadCards();
+    }
 
     async function loadCards() {
-      const res = await fetch('/api/cards?items=1');
+      const res = await fetch('/api/cards?items=1', {
+        headers: token ? { 'Authorization': 'Bearer ' + token } : {}
+      });
       allCards = await res.json();
       renderCards(allCards);
+    }
+
+    function connectWS() {
+      socket = new WebSocket(`ws://${location.host}/ws`);
+      socket.onmessage = (e) => {
+        const msg = JSON.parse(e.data);
+        if (msg.type === 'reset') return loadCards();
+        const t = document.querySelector(`[data-task="${msg.taskId}"]`);
+        if (t) {
+          t.checked = msg.checked;
+          t.parentElement.style.background = msg.color;
+          t.parentElement.title = `Checked by ${msg.user}`;
+        }
+      };
     }
 
     function renderCards(cards) {
@@ -38,9 +79,28 @@
         text.textContent = card.card_text;
         const ul = document.createElement('ul');
         ul.className = 'item-list';
-        for (const item of card.items) {
+        for (const task of card.tasks) {
           const li = document.createElement('li');
-          li.textContent = `${item.name} - Room ${item.room}, Drawer ${item.drawer_code}`;
+          const cb = document.createElement('input');
+          cb.type = 'checkbox';
+          cb.dataset.task = task.id;
+          cb.checked = task.is_checked;
+          if (task.color) {
+            li.style.background = task.color;
+            li.title = `Checked by ${task.username}`;
+          }
+          cb.addEventListener('change', async () => {
+            await fetch('/api/tasks/check', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + token
+              },
+              body: JSON.stringify({ taskId: task.id, checked: cb.checked })
+            });
+          });
+          li.appendChild(cb);
+          li.appendChild(document.createTextNode(' ' + task.description));
           ul.appendChild(li);
         }
         div.appendChild(title);
@@ -50,13 +110,12 @@
       }
     }
 
+    document.getElementById('loginBtn').onclick = login;
     document.getElementById('search').addEventListener('input', (e) => {
       const value = e.target.value.toLowerCase();
       const filtered = allCards.filter(c => c.class.toLowerCase().includes(value));
       renderCards(filtered);
     });
-
-    loadCards();
   </script>
 </body>
 </html>

--- a/server.ts
+++ b/server.ts
@@ -1,12 +1,56 @@
 import { serveFile } from "https://deno.land/std@0.214.0/http/file_server.ts";
 import { serve } from "https://deno.land/std@0.214.0/http/server.ts";
 import { db } from "./database.ts";
+import { createToken, verifyToken } from "./auth.ts";
+
+const sockets = new Set<WebSocket>();
 
 async function handler(request: Request): Promise<Response> {
   const url = new URL(request.url);
+
+  if (url.pathname === "/ws") {
+    const { socket, response } = Deno.upgradeWebSocket(request);
+    sockets.add(socket);
+    socket.onclose = () => sockets.delete(socket);
+    return response;
+  }
   if (url.pathname === "/api/greet") {
     const body = JSON.stringify({ message: "Hello from Deno!" });
     return new Response(body, {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (url.pathname === "/api/login" && request.method === "POST") {
+    const { username, password } = await request.json();
+    const row = [...db.query(
+      "SELECT id, password, role, color FROM users WHERE username = ?",
+      [username],
+    )][0];
+    if (!row) {
+      return new Response("invalid", { status: 401 });
+    }
+    const [id, hash, role] = [row[0], row[1], row[2]];
+    const bcrypt = await import("https://deno.land/x/bcrypt/mod.ts");
+    const ok = await bcrypt.compare(password, hash);
+    if (!ok) return new Response("invalid", { status: 401 });
+    const token = await createToken({ id, username, role });
+    return new Response(JSON.stringify({ token, role }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (url.pathname === "/api/users" && request.method === "GET") {
+    const auth = request.headers.get("authorization");
+    if (!auth) return new Response("unauthorized", { status: 401 });
+    const session = await verifyToken(auth.replace("Bearer ", ""));
+    if (!session || session.role !== "root") {
+      return new Response("forbidden", { status: 403 });
+    }
+    const users = [...db.query("SELECT id, username, role, color FROM users")].map(
+      ([id, user, role, color]) => ({ id, username: user, role, color }),
+    );
+    return new Response(JSON.stringify(users), {
       headers: { "Content-Type": "application/json" },
     });
   }
@@ -49,12 +93,63 @@ async function handler(request: Request): Promise<Response> {
           room,
           drawer_code: drawer,
         }));
+        card.tasks = [...db.query(
+          `SELECT ct.id, ct.description, ct.is_checked, ct.checked_by, ct.checked_at, u.username, u.color
+             FROM card_tasks ct
+             LEFT JOIN users u ON ct.checked_by = u.id
+             WHERE ct.card_id = ?`,
+          [card.id],
+        )].map(([tid, desc, checked, by, at, user, color]) => ({
+          id: tid,
+          description: desc,
+          is_checked: !!checked,
+          checked_by: by,
+          checked_at: at,
+          username: user,
+          color,
+        }));
       }
     }
 
     return new Response(JSON.stringify(cards), {
       headers: { "Content-Type": "application/json" },
     });
+  }
+
+  if (url.pathname === "/api/tasks/check" && request.method === "POST") {
+    const auth = request.headers.get("authorization");
+    if (!auth) return new Response("unauthorized", { status: 401 });
+    const token = auth.replace("Bearer ", "");
+    const session = await verifyToken(token);
+    if (!session) return new Response("unauthorized", { status: 401 });
+
+    const { taskId, checked } = await request.json();
+    db.query(
+      `UPDATE card_tasks SET is_checked = ?, checked_by = ?, checked_at = datetime('now') WHERE id = ?`,
+      [checked ? 1 : 0, session.id, taskId],
+    );
+    const uRow = [...db.query("SELECT color FROM users WHERE id = ?", [session.id])][0];
+    const color = uRow ? uRow[0] : null;
+    const payload = { taskId, checked, user: session.username, color };
+    for (const s of sockets) {
+      try { s.send(JSON.stringify(payload)); } catch (_) {}
+    }
+    return new Response("ok");
+  }
+
+  if (url.pathname === "/api/reset-semester" && request.method === "POST") {
+    const auth = request.headers.get("authorization");
+    if (!auth) return new Response("unauthorized", { status: 401 });
+    const token = auth.replace("Bearer ", "");
+    const session = await verifyToken(token);
+    if (!session || session.role !== "root") {
+      return new Response("forbidden", { status: 403 });
+    }
+    db.query("UPDATE card_tasks SET is_checked = 0, checked_by = NULL, checked_at = NULL");
+    for (const s of sockets) {
+      try { s.send(JSON.stringify({ type: "reset" })); } catch (_) {}
+    }
+    return new Response("ok");
   }
 
   const filePath = url.pathname === "/" ? "/index.html" : url.pathname;


### PR DESCRIPTION
## Summary
- implement JWT-based auth helpers in `auth.ts`
- extend DB schema with `users` and `card_tasks` tables and seed demo data
- expose new API endpoints in `server.ts` for login, user listing, task check and semester reset
- deliver tasks with user and color info and broadcast updates via WebSocket
- add login UI and live checkboxes in `public/index.html`

## Testing
- `apt-get update` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6887bee68a8c8323a946bb8a827a8e22